### PR TITLE
Using Option::from, instead of Option::just, to wrap map's function call

### DIFF
--- a/src/Option.php
+++ b/src/Option.php
@@ -107,7 +107,7 @@ final class Option implements \IteratorAggregate {
      * $f should take the wrapped value and return a new value
      */
     public function map(callable $f) {
-        return !$this->isEmpty() ? Option::just($f($this->get())) : Option::none();
+        return !$this->isEmpty() ? Option::from($f($this->get())) : Option::none();
     }
     
     /**


### PR DESCRIPTION
if the mapped function returns null, it will become a None, instead of throwing an exception.

Not sure if this is overstepping the map functions responsibility, but I'd rather a None than an Exception.
